### PR TITLE
Uses fifo instead of telnet, delay optional, removed heatbeat. Resolves #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # Intercom
 CSH Intercom Project.
 
+## Usage
+```
+echo [Message] > [fifopath]
+```
+
+## Future plans
+* Absolute times instead of delays.
+* Web Interface
+
 ## Installation
 ```
-sudo apt-get install espeak
+sudo apt-get install espeak python-dev
 pip install -r requirements.txt
-python client/checker.py
+python client/client.py
 
 
 or

--- a/client/client.py
+++ b/client/client.py
@@ -19,8 +19,6 @@ class IntercomProtocol(LineReceiver):
         print("Connected successfully")
         c = task.LoopingCall(self.check)
         c.start(5.0)
-        h = task.LoopingCall(self.heartbeat)
-        h.start(5.0)
 
     def lineReceived(self, line):
         if line:
@@ -28,13 +26,10 @@ class IntercomProtocol(LineReceiver):
             if len(parts) >= 2:
                 parts[0]=' '.join(parts[:-1])
                 parts[1]=parts[-1]
-                print(parts[-1],"New Message Recieved: ",parts[0])
+                print(parts[1],"New Message Recieved: ",parts[0])
                 sc = plugins.command.SayCommand(parts[0])
                 self.factory.heap.push(float(parts[1]), sc)
     
-    def heartbeat(self):
-        self.sendLine("<3<3".encode('utf-8'))
-
 
 class IntercomClientFactory(protocol.ClientFactory):
     protocol = IntercomProtocol

--- a/client/client.py
+++ b/client/client.py
@@ -26,10 +26,11 @@ class IntercomProtocol(LineReceiver):
         if line:
             parts = line.decode('utf-8','ignore').split("|")
             if len(parts) >= 2:
-                parts[1]=' '.join(parts[1:])
-                print(parts[0],"New Message Recieved: ",parts[1])
-                sc = plugins.command.SayCommand(parts[1])
-                self.factory.heap.push(float(parts[0]), sc)
+                parts[0]=' '.join(parts[:-1])
+                parts[1]=parts[-1]
+                print(parts[-1],"New Message Recieved: ",parts[0])
+                sc = plugins.command.SayCommand(parts[0])
+                self.factory.heap.push(float(parts[1]), sc)
     
     def heartbeat(self):
         self.sendLine("<3<3".encode('utf-8'))


### PR DESCRIPTION
Changes the format for messages slightly:

Messages can be sent a default delay of 5, or with a relative delay specified at the end of the message separated by a pipe.
Ex:

```
echo [Message] > [fifopath]
```

or

```
echo [Message]|[Delay] > [fifopath]
```
